### PR TITLE
Constructible atmos UI stuff!

### DIFF
--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -50,8 +50,8 @@
 
 /obj/item/handheld_dispenser/ui_data(mob/user)
 	. = list(
-		"selectedimage" = (src.selectedimage || getBase64Img(selection)),
-		"mode" = src.destroying
+		"selectedimage" = (src.selectedimage || getBase64Img(selection, src.direction)),
+		"destroying" = src.destroying
 	)
 
 /obj/item/handheld_dispenser/ui_static_data(mob/user)
@@ -60,12 +60,14 @@
 	for (var/itemtype in atmospipesforcreation)
 		.["atmospipes"] += list(list(
 			"type" = itemtype,
-			"image" = getBase64Img(atmospipesforcreation[itemtype])
+			"image" = getBase64Img(atmospipesforcreation[itemtype]),
+			"cost" = 4,
 			))
 	for (var/itemtype in atmosmachinesforcreation)
 		.["atmosmachines"] += list(list(
 			"type" = itemtype,
-			"image" = getBase64Img(atmosmachinesforcreation[itemtype])
+			"image" = getBase64Img(atmosmachinesforcreation[itemtype]),
+			"cost" = 4,
 			))
 
 /obj/item/handheld_dispenser/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -79,6 +81,12 @@
 			. = TRUE
 		if("changedir")
 			src.direction = text2num_safe(params["newdir"])
+			//invalidate the cached selected image
+			src.selectedimage = null
+			. = TRUE
+		if("toggle-destroying")
+			src.destroying = !src.destroying
+			. = TRUE
 
 /obj/item/handheld_dispenser/proc/getBase64Img(atom/object, direction = SOUTH)
 	. = src.cache["[object][direction]"]

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -31,6 +31,7 @@
 	var/selectedimage
 	var/direction = EAST
 	var/destroying = FALSE
+	var/resources = 20
 
 /obj/item/handheld_dispenser/attack_self(mob/user )
 	src.ui_interact(user)
@@ -51,7 +52,9 @@
 /obj/item/handheld_dispenser/ui_data(mob/user)
 	. = list(
 		"selectedimage" = (src.selectedimage || getBase64Img(selection, src.direction)),
-		"destroying" = src.destroying
+		"selectedcost" = 3, //TODO when datumized
+		"resources" = src.resources,
+		"destroying" = src.destroying,
 	)
 
 /obj/item/handheld_dispenser/ui_static_data(mob/user)
@@ -61,7 +64,7 @@
 		.["atmospipes"] += list(list(
 			"type" = itemtype,
 			"image" = getBase64Img(atmospipesforcreation[itemtype]),
-			"cost" = 4,
+			"cost" = 4, //TODO when datumized
 			))
 	for (var/itemtype in atmosmachinesforcreation)
 		.["atmosmachines"] += list(list(

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser.tsx
@@ -16,42 +16,87 @@ import {
 } from 'tgui-core/components';
 
 import { useBackend, useSharedState } from '../backend';
+import { Icon } from '../components';
 import { Window } from '../layouts';
 
 interface HandPipeDispenserData {
   atmospipes;
   atmosmachines;
-  selectedimage;
+  selectedimage: string; // base64 image
+  destroying : boolean;
 }
 
-const Tab = {
-  AtmosPipes: 'atmospipes',
-  AtmosMachines: 'atmosmachines',
-};
+// I feel like this should be common somewhere but :iiam:
+enum ByondDir {
+  North = 1,
+  South = 2,
+  East = 4,
+  West = 8,
+}
+
+enum Tab {
+  AtmosPipes = 'atmospipes',
+  AtmosMachines = 'atmosmachines',
+}
 
 export const HandPipeDispenser = () => {
-  const { data } = useBackend<HandPipeDispenserData>();
+  const { act, data } = useBackend<HandPipeDispenserData>();
   const { atmospipes, atmosmachines, selectedimage } = data;
   const [tab, setTab] = useSharedState('tab', Tab.AtmosPipes);
   return (
-    <Window width={400} height={350}>
+    <Window width={450} height={350}>
       <Flex height="100%">
         <Flex.Item fill>
-          <Section fill>
-            <Button color="green">Create</Button>
-            <br />
-            <Button color="red">Remove</Button>
-            <br />
-            <Box
-              style={{
-                border: '1px solid grey',
-              }}
-            >
-              <Image
-                style={{ width: 64, height: 64 }}
-                src={`data:image/png;base64,${selectedimage}`}
-              />
-            </Box>
+          <Section fill title={<>Resources: 28 <Icon name="boxes-stacked" /></>}>
+            {/* <LabeledList>
+              <LabeledList.Item label="Cost">
+                3 <Icon name="boxes-stacked" />
+              </LabeledList.Item>
+            </LabeledList> */}
+            {/* Stack hell zone aka the preview with buttons */}
+            <Stack vertical>
+              <Stack.Item>
+                <Box textAlign="center">
+                  <Button icon="arrow-up" onClick={() => act('changedir', { newdir: ByondDir.North })} />
+                </Box>
+              </Stack.Item>
+              <Stack.Item>
+                <Flex align="center" justify="space-around">
+                  <Flex.Item>
+                    <Button icon="arrow-left" onClick={() => act('changedir', { newdir: ByondDir.West })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Box
+                      style={{
+                        border: '1px solid grey',
+                      }}
+                    >
+                      <Image
+                        style={{ width: 64, height: 64 }}
+                        src={`data:image/png;base64,${selectedimage}`}
+                      />
+                    </Box>
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button icon="arrow-right" onClick={() => act('changedir', { newdir: ByondDir.East })} />
+                  </Flex.Item>
+                </Flex>
+              </Stack.Item>
+              <Stack.Item>
+                <Box textAlign="center">
+                  <Button icon="arrow-down" onClick={() => act('changedir', { newdir: ByondDir.South })} />
+                </Box>
+              </Stack.Item>
+              <Stack.Item>
+                {/* Mode switch button */}
+                { data.destroying && (
+                  <Button textAlign="center" width="100%" color="red" icon="xmark" onClick={() => act('toggle-destroying')}>Removing</Button>
+                )}
+                { !data.destroying && (
+                  <Button textAlign="center" width="100%" color="green" icon="plus" onClick={() => act('toggle-destroying')}>Placing</Button>
+                )}
+              </Stack.Item>
+            </Stack>
           </Section>
         </Flex.Item>
         <Flex.Item position="relative" ml={1} grow fill>
@@ -106,7 +151,12 @@ export const ItemRow = (props) => {
           </Box>
         </Stack.Item>
       )}
-      <Stack.Item grow>{item.type}</Stack.Item>
+      <Stack.Item grow>
+        {item.type}
+        <br />
+        {item.cost}
+        <Icon name="boxes-stacked" />
+      </Stack.Item>
       <Stack.Item
         style={{
           marginLeft: '5px',

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
@@ -12,7 +12,8 @@ import {
   Image,
   Section,
   Stack,
-  Tabs } from 'tgui-core/components';
+  Tabs,
+} from 'tgui-core/components';
 
 import { useBackend, useSharedState } from '../../backend';
 import { Icon } from '../../components';
@@ -21,25 +22,43 @@ import { ByondDir, HandPipeDispenserData, PipeData, Tab } from './type';
 
 export const HandPipeDispenser = () => {
   const { act, data } = useBackend<HandPipeDispenserData>();
-  const { atmospipes, atmosmachines, selectedimage, selectedcost, resources } = data;
+  const { atmospipes, atmosmachines, selectedimage, selectedcost, resources } =
+    data;
   const [tab, setTab] = useSharedState('tab', Tab.AtmosPipes);
   return (
     <Window width={450} height={350}>
       <Flex height="100%">
         <Flex.Item fill>
-          <Section fill title={<>Resources: {resources} <Icon name="boxes-stacked" /></>}>
+          <Section
+            fill
+            title={
+              <>
+                Resources: {resources} <Icon name="boxes-stacked" />
+              </>
+            }
+          >
             {/* Stack hell zone aka the preview with buttons */}
             <Stack vertical>
-              <Box position="absolute" right="7px">{selectedcost} <Icon name="boxes-stacked" /></Box>
+              <Box position="absolute" right="7px">
+                {selectedcost} <Icon name="boxes-stacked" />
+              </Box>
               <Stack.Item>
                 <Box textAlign="center">
-                  <Button icon="arrow-up" onClick={() => act('changedir', { newdir: ByondDir.North })} />
+                  <Button
+                    icon="arrow-up"
+                    onClick={() => act('changedir', { newdir: ByondDir.North })}
+                  />
                 </Box>
               </Stack.Item>
               <Stack.Item>
                 <Flex align="center" justify="space-around">
                   <Flex.Item>
-                    <Button icon="arrow-left" onClick={() => act('changedir', { newdir: ByondDir.West })} />
+                    <Button
+                      icon="arrow-left"
+                      onClick={() =>
+                        act('changedir', { newdir: ByondDir.West })
+                      }
+                    />
                   </Flex.Item>
                   <Flex.Item>
                     <Box
@@ -54,22 +73,46 @@ export const HandPipeDispenser = () => {
                     </Box>
                   </Flex.Item>
                   <Flex.Item>
-                    <Button icon="arrow-right" onClick={() => act('changedir', { newdir: ByondDir.East })} />
+                    <Button
+                      icon="arrow-right"
+                      onClick={() =>
+                        act('changedir', { newdir: ByondDir.East })
+                      }
+                    />
                   </Flex.Item>
                 </Flex>
               </Stack.Item>
               <Stack.Item>
                 <Box textAlign="center">
-                  <Button icon="arrow-down" onClick={() => act('changedir', { newdir: ByondDir.South })} />
+                  <Button
+                    icon="arrow-down"
+                    onClick={() => act('changedir', { newdir: ByondDir.South })}
+                  />
                 </Box>
               </Stack.Item>
               <Stack.Item>
                 {/* Mode switch button */}
-                { !!data.destroying && (
-                  <Button textAlign="center" width="100%" color="red" icon="xmark" onClick={() => act('toggle-destroying')}>Removing</Button>
+                {!!data.destroying && (
+                  <Button
+                    textAlign="center"
+                    width="100%"
+                    color="red"
+                    icon="xmark"
+                    onClick={() => act('toggle-destroying')}
+                  >
+                    Removing
+                  </Button>
                 )}
-                { !data.destroying && (
-                  <Button textAlign="center" width="100%" color="green" icon="plus" onClick={() => act('toggle-destroying')}>Placing</Button>
+                {!data.destroying && (
+                  <Button
+                    textAlign="center"
+                    width="100%"
+                    color="green"
+                    icon="plus"
+                    onClick={() => act('toggle-destroying')}
+                  >
+                    Placing
+                  </Button>
                 )}
               </Stack.Item>
             </Stack>
@@ -94,15 +137,17 @@ export const HandPipeDispenser = () => {
               </Tabs>
               {tab === Tab.AtmosPipes && (
                 <Section>
-                  {atmospipes.map((atmospipe : PipeData) => {
+                  {atmospipes.map((atmospipe: PipeData) => {
                     return <ItemRow {...atmospipe} key={atmospipe.type} />;
                   })}
                 </Section>
               )}
               {tab === Tab.AtmosMachines && (
                 <Section>
-                  {atmosmachines.map((atmosmachine : PipeData) => {
-                    return <Box key={atmosmachine.type}><ItemRow {...atmosmachine} /></Box>;
+                  {atmosmachines.map((atmosmachine: PipeData) => {
+                    return (
+                      <ItemRow key={atmosmachine.type} {...atmosmachine} />
+                    );
                   })}
                 </Section>
               )}

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
@@ -95,7 +95,7 @@ export const HandPipeDispenser = () => {
               {tab === Tab.AtmosPipes && (
                 <Section>
                   {atmospipes.map((atmospipe : PipeData) => {
-                    return <Box key={atmospipe.type}><ItemRow {...atmospipe} /></Box>;
+                    return <ItemRow {...atmospipe} key={atmospipe.type} />;
                   })}
                 </Section>
               )}

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
@@ -12,8 +12,7 @@ import {
   Image,
   Section,
   Stack,
-  Tabs,
-} from 'tgui-core/components';
+  Tabs } from 'tgui-core/components';
 
 import { useBackend, useSharedState } from '../../backend';
 import { Icon } from '../../components';
@@ -22,20 +21,16 @@ import { ByondDir, HandPipeDispenserData, PipeData, Tab } from './type';
 
 export const HandPipeDispenser = () => {
   const { act, data } = useBackend<HandPipeDispenserData>();
-  const { atmospipes, atmosmachines, selectedimage } = data;
+  const { atmospipes, atmosmachines, selectedimage, selectedcost, resources } = data;
   const [tab, setTab] = useSharedState('tab', Tab.AtmosPipes);
   return (
     <Window width={450} height={350}>
       <Flex height="100%">
         <Flex.Item fill>
-          <Section fill title={<>Resources: 28 <Icon name="boxes-stacked" /></>}>
-            {/* <LabeledList>
-              <LabeledList.Item label="Cost">
-                3 <Icon name="boxes-stacked" />
-              </LabeledList.Item>
-            </LabeledList> */}
+          <Section fill title={<>Resources: {resources} <Icon name="boxes-stacked" /></>}>
             {/* Stack hell zone aka the preview with buttons */}
             <Stack vertical>
+              <Box position="absolute" right="7px">{selectedcost} <Icon name="boxes-stacked" /></Box>
               <Stack.Item>
                 <Box textAlign="center">
                   <Button icon="arrow-up" onClick={() => act('changedir', { newdir: ByondDir.North })} />

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
@@ -18,26 +18,7 @@ import {
 import { useBackend, useSharedState } from '../backend';
 import { Icon } from '../components';
 import { Window } from '../layouts';
-
-interface HandPipeDispenserData {
-  atmospipes;
-  atmosmachines;
-  selectedimage: string; // base64 image
-  destroying : boolean;
-}
-
-// I feel like this should be common somewhere but :iiam:
-enum ByondDir {
-  North = 1,
-  South = 2,
-  East = 4,
-  West = 8,
-}
-
-enum Tab {
-  AtmosPipes = 'atmospipes',
-  AtmosMachines = 'atmosmachines',
-}
+import { ByondDir, HandPipeDispenserData, PipeData, Tab } from './type';
 
 export const HandPipeDispenser = () => {
   const { act, data } = useBackend<HandPipeDispenserData>();
@@ -118,15 +99,15 @@ export const HandPipeDispenser = () => {
               </Tabs>
               {tab === Tab.AtmosPipes && (
                 <Section>
-                  {atmospipes.map((atmospipe) => {
-                    return <ItemRow key={atmospipe} item={atmospipe} />;
+                  {atmospipes.map((atmospipe : PipeData) => {
+                    return <ItemRow key={atmospipe.type} item={atmospipe} />;
                   })}
                 </Section>
               )}
               {tab === Tab.AtmosMachines && (
                 <Section>
-                  {atmosmachines.map((atmosmachine) => {
-                    return <ItemRow key={atmosmachine} item={atmosmachine} />;
+                  {atmosmachines.map((atmosmachine : PipeData) => {
+                    return <ItemRow key={atmosmachine.type} item={atmosmachine} />;
                   })}
                 </Section>
               )}
@@ -138,9 +119,8 @@ export const HandPipeDispenser = () => {
   );
 };
 
-export const ItemRow = (props) => {
+export const ItemRow = (item: PipeData) => {
   const { act } = useBackend();
-  const { item } = props;
 
   return (
     <Stack style={{ borderBottom: '1px #555 solid' }}>

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/index.tsx
@@ -15,9 +15,9 @@ import {
   Tabs,
 } from 'tgui-core/components';
 
-import { useBackend, useSharedState } from '../backend';
-import { Icon } from '../components';
-import { Window } from '../layouts';
+import { useBackend, useSharedState } from '../../backend';
+import { Icon } from '../../components';
+import { Window } from '../../layouts';
 import { ByondDir, HandPipeDispenserData, PipeData, Tab } from './type';
 
 export const HandPipeDispenser = () => {
@@ -70,7 +70,7 @@ export const HandPipeDispenser = () => {
               </Stack.Item>
               <Stack.Item>
                 {/* Mode switch button */}
-                { data.destroying && (
+                { !!data.destroying && (
                   <Button textAlign="center" width="100%" color="red" icon="xmark" onClick={() => act('toggle-destroying')}>Removing</Button>
                 )}
                 { !data.destroying && (
@@ -100,14 +100,14 @@ export const HandPipeDispenser = () => {
               {tab === Tab.AtmosPipes && (
                 <Section>
                   {atmospipes.map((atmospipe : PipeData) => {
-                    return <ItemRow key={atmospipe.type} item={atmospipe} />;
+                    return <Box key={atmospipe.type}><ItemRow {...atmospipe} /></Box>;
                   })}
                 </Section>
               )}
               {tab === Tab.AtmosMachines && (
                 <Section>
                   {atmosmachines.map((atmosmachine : PipeData) => {
-                    return <ItemRow key={atmosmachine.type} item={atmosmachine} />;
+                    return <Box key={atmosmachine.type}><ItemRow {...atmosmachine} /></Box>;
                   })}
                 </Section>
               )}
@@ -134,8 +134,7 @@ export const ItemRow = (item: PipeData) => {
       <Stack.Item grow>
         {item.type}
         <br />
-        {item.cost}
-        <Icon name="boxes-stacked" />
+        {item.cost} <Icon name="boxes-stacked" />
       </Stack.Item>
       <Stack.Item
         style={{

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
@@ -10,6 +10,8 @@ export type HandPipeDispenserData = {
   atmosmachines: PipeData[];
   selectedimage: string; // base64 image
   destroying : boolean;
+  selectedcost: number;
+  resources: number;
 }
 
 // I feel like this should be common somewhere but :iiam:

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
@@ -1,0 +1,26 @@
+
+export type PipeData = {
+  type: string;
+  image: string; // base64
+  cost: number;
+}
+
+export type HandPipeDispenserData = {
+  atmospipes: PipeData[];
+  atmosmachines: PipeData[];
+  selectedimage: string; // base64 image
+  destroying : boolean;
+}
+
+// I feel like this should be common somewhere but :iiam:
+export enum ByondDir {
+  North = 1,
+  South = 2,
+  East = 4,
+  West = 8,
+}
+
+export enum Tab {
+  AtmosPipes = 'atmospipes',
+  AtmosMachines = 'atmosmachines',
+}

--- a/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
+++ b/tgui/packages/tgui/interfaces/HandPipeDispenser/type.ts
@@ -1,18 +1,17 @@
-
 export type PipeData = {
   type: string;
   image: string; // base64
   cost: number;
-}
+};
 
 export type HandPipeDispenserData = {
   atmospipes: PipeData[];
   atmosmachines: PipeData[];
   selectedimage: string; // base64 image
-  destroying : boolean;
+  destroying: boolean;
   selectedcost: number;
   resources: number;
-}
+};
 
 // I feel like this should be common somewhere but :iiam:
 export enum ByondDir {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://github.com/user-attachments/assets/e7b8f488-6e1a-4040-a106-8178b042b801)

Expands the UI a bit, adding some missing features and making it a bit more typescript. Some of the numbers are still placeholders pending pipe placement datums or other cost handling.
